### PR TITLE
clickAnchor() only stopPropogation if valid link

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -423,14 +423,13 @@
                  * 
                  */
                 clickAnchor = function (event) {
-                    // stopPropagation so that event doesn't fire on parent containers.
-                    event.stopPropagation();
-
                     var $anchor     = $(event.currentTarget),
                         url         = $anchor.prop("href"),
                         $container  = $(event.delegateTarget);
 
                     if (utility.shouldLoad($anchor, options.blacklist)) {
+                        // stopPropagation so that event doesn't fire on parent containers.
+                        event.stopPropagation();
                         event.preventDefault();
                         load(url);
                     }


### PR DESCRIPTION
Running event.stopPropogation on all links was causing problems with other plugins (e.g. Bootstrap 3 Carousel direction links: see point 2 in issue https://github.com/miguel-perez/jquery.smoothState.js/issues/9).

Moving event.stopPropagation(); call into the shouldLoad condition resolves this.
