### PR TITLE
Teach bindEventHandlers() to use new "anchors" option

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -27,6 +27,9 @@
         /** Plugin default options */
         defaults    = {
 
+            /** jquery element string to specify which anchors smoothstate should bind too */
+            anchors : "a",
+
             /** If set to true, smoothState will prefetch a link's contents on hover */
             prefetch : false,
             
@@ -444,9 +447,9 @@
                  */
                 bindEventHandlers = function ($element) {
                     //@todo: Handle form submissions
-                    $element.on("click", "a", clickAnchor);
+                    $element.on("click", options.anchors, clickAnchor);
                     if (options.prefetch) {
-                        $element.on("mouseover touchstart", "a", hoverAnchor);
+                        $element.on("mouseover touchstart", options.anchors, hoverAnchor);
                     }
                 },
 


### PR DESCRIPTION
Related to https://github.com/miguel-perez/jquery.smoothState.js/issues/9#issuecomment-51224288

Addition of an "anchors" option which defaults to "a" and is used by the bindEventHandlers() function.

By default, smoothstate will operate as @miguel-perez intended (binding to all links other than those matching "blacklist" selector string), but if user provides their own "anchors" value will allow them to bind smoothstate to subset(s) of links.
