### PR TITLE
Watch only container element animation #13

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -235,14 +235,18 @@
                         utility.redraw($element);
                     },
                     onAnimationStart    = function (e) {
-                        e.stopPropagation();
-                        animationCount ++;
+                        if ($(e.target).is($element)) {
+                            e.stopPropagation();
+                            animationCount ++;
+                        }
                     },
                     onAnimationEnd      = function (e) {
-                        e.stopPropagation();
-                        animationCount --;
-                        if(animationCount === 0) {
-                            unbindHandlers();
+                        if ($(e.target).is($element)) {
+                            e.stopPropagation();
+                            animationCount --;
+                            if(animationCount === 0) {
+                                unbindHandlers();
+                            }
                         }
                     };
                 


### PR DESCRIPTION
Use `onAnimationStart` and `onAnimationEnd` only if the target event is the
container element, and not a parent or other (like `window.requestAnimationFrame`).
