### PR TITLE
Bugfix: Trim inner content

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -208,7 +208,7 @@
             getContentById: function (id, $html) {
                 $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
                 var $insideElem         = $html.find(id),
-                    updatedContainer    = ($insideElem.length) ? $insideElem.html() : $html.filter(id).html(),
+                    updatedContainer    = ($insideElem.length) ? $.trim($insideElem.html()) : $html.filter(id).html(),
                     newContent          = (updatedContainer.length) ? $(updatedContainer) : null;
                 return newContent;
             },


### PR DESCRIPTION
If the smoothState object started with a blank line, parser would choke. 
Trimming the input string before passing it to jQuery for parsing fixes the bug.
