### PR TITLE
[BUGFIX] Fixes repeating animation issue in IE 11 and below

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -271,9 +271,8 @@
 
             /** Forces browser to redraw elements */
             redraw: function ($element) {
-                $element.hide(0, function() {
-                    $(this).show();
-                });
+                $element.height(0);
+			    setTimeout(function(){$element.height('auto');}, 0);
             }
         },
 


### PR DESCRIPTION
See: https://github.com/miguel-perez/jquery.smoothState.js/issues/26

Next try ... This one has one problem but works good so far. $element ist forced to height: auto;. Any suggestions?

I have tested IE 11,10,9,8, Chrome 36 and FF 31 on Win 8.1.
I cannot see any problems with it, please test it as well.
