### PR TITLE
#34 : Fix Ctrl + click not opening a new tab

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -474,7 +474,8 @@
                         url         = $anchor.prop("href"),
                         $container  = $(event.delegateTarget);
 
-                    if (utility.shouldLoad($anchor, options.blacklist)) {
+                    // Ctrl (or Cmd) + click must open a new tab
+                    if (!event.metaKey && !event.ctrlKey && utility.shouldLoad($anchor, options.blacklist)) {
                         // stopPropagation so that event doesn't fire on parent containers.
                         event.stopPropagation();
                         event.preventDefault();


### PR DESCRIPTION
Don't load url if user hold Ctrl or Cmd when he click (default behaviour
so)
