### PR TITLE
[FEATURE] Replace meta and link tags

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -1,12 +1,12 @@
 /**
  * smoothState.js is a jQuery plugin to stop page load jank.
  *
- * This jQuery plugin progressively enhances page loads to 
+ * This jQuery plugin progressively enhances page loads to
  * behave more like a single-page application.
  *
  * @author  Miguel Ángel Pérez   reachme@miguel-perez.com
  * @see     https://github.com/miguel-perez/jquery.smoothState.js
- * 
+ *
  */
 ;(function ( $, window, document, undefined ) {
     "use strict";
@@ -14,10 +14,10 @@
     var
         /** Used later to scroll page to the top */
         $body       = $("html, body"),
-        
+
         /** Used in development mode to console out useful warnings */
         consl       = (window.console || false),
-        
+
         /** Plugin default options */
         defaults    = {
 
@@ -26,24 +26,24 @@
 
             /** If set to true, smoothState will prefetch a link's contents on hover */
             prefetch : false,
-            
+
             /** A selecor that deinfes with links should be ignored by smoothState */
             blacklist : ".no-smoothstate, [target]",
-            
+
             /** If set to true, smoothState will log useful debug information instead of aborting */
             development : false,
-            
+
             /** The number of pages smoothState will try to store in memory and not request again */
             pageCacheSize : 0,
-			
-			/** An array of selectors that defines head tags which should be replaced by the head tags of requested page. Meta and link tags are supported */
-			headTagSelectors : ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]','meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
-            
+
+            /** An array of selectors that defines head tags which should be replaced by the head tags of requested page. Meta and link tags are supported */
+            headTagSelectors : ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]','meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
+
             /** A function that can be used to alter urls before they are used to request content */
             alterRequestUrl : function (url) {
                 return url;
             },
-            
+
             /** Run when a link has been activated */
             onStart : {
                 duration: 0,
@@ -76,56 +76,56 @@
 
             }
         },
-        
+
         /** Utility functions that are decoupled from SmoothState */
         utility     = {
-		
-			/**
-			 * Replace head tags in current doc with tags from loaded doc
-			 * @param   {obj}       cachedDoc - cached document
-			 * @param   {array}     headTagSelectors - head tag selectors
-			 *
-			 */
-			replaceHeadTags: function (cachedDoc, headTagSelectors) {
 
-				var $cachedDoc = cachedDoc.find("head"),
-					$currentDoc = $("head");
+            /**
+             * Replace head tags in current doc with tags from loaded doc
+             * @param   {obj}       cachedDoc - cached document
+             * @param   {array}     headTagSelectors - head tag selectors
+             *
+             */
+            replaceHeadTags: function (cachedDoc, headTagSelectors) {
 
-				// Check each selector in current and cached document
-				$(headTagSelectors).each(function(i,headTagSelector) {
+                var $cachedDoc = cachedDoc.find("head"),
+                    $currentDoc = $("head");
 
-					var $headTag = $cachedDoc.find(headTagSelector),
-						headTagType = ($headTag.length > 0) ? $headTag.prop("tagName").toLowerCase() : false,
-						headTagAttribute;
+                // Check each selector in current and cached document
+                $(headTagSelectors).each(function(i,headTagSelector) {
 
-					if(headTagType){
+                    var $headTag = $cachedDoc.find(headTagSelector),
+                        headTagType = ($headTag.length > 0) ? $headTag.prop("tagName").toLowerCase() : false,
+                        headTagAttribute;
 
-						// Supported tags are link and meta
-						switch(headTagType){
-							case "link":
-								headTagAttribute = "href";
-							break;
-							case "meta":
-								headTagAttribute = "content";
-							break;
-							default:
-								headTagAttribute = false;
-							break;
-						}
+                    if(headTagType){
 
-						if(headTagAttribute){
-							// Replace tag content
-							$currentDoc.find(headTagSelector).attr(headTagAttribute,$headTag.attr(headTagAttribute));
-						}
-					}
-				});
-			},
+                        // Supported tags are link and meta
+                        switch(headTagType){
+                            case "link":
+                                headTagAttribute = "href";
+                            break;
+                            case "meta":
+                                headTagAttribute = "content";
+                            break;
+                            default:
+                                headTagAttribute = false;
+                            break;
+                        }
+
+                        if(headTagAttribute){
+                            // Replace tag content
+                            $currentDoc.find(headTagSelector).attr(headTagAttribute,$headTag.attr(headTagAttribute));
+                        }
+                    }
+                });
+            },
 
             /**
              * Checks to see if the url is external
              * @param   {string}    url - url being evaluated
              * @see     http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
-             * 
+             *
              */
             isExternal: function (url) {
                 var match = url.match(/^([^:\/?#]+:)?(?:\/\/([^\/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/);
@@ -141,7 +141,7 @@
             /**
              * Checks to see if the url is an internal hash
              * @param   {string}    url - url being evaluated
-             * 
+             *
              */
             isHash: function (url) {
                 var hasPathname = (url.indexOf(window.location.pathname) > 0) ? true : false,
@@ -153,7 +153,7 @@
              * Checks to see if we should be loading this URL
              * @param   {string}    url - url being evaluated
              * @param   {string}    blacklist - jquery selector
-             * 
+             *
              */
             shouldLoad: function ($anchor, blacklist) {
                 var url = $anchor.prop("href");
@@ -166,7 +166,7 @@
              * @param   {string}    url - url being evaluated
              * @author  Ben Alman   http://benalman.com/
              * @see     https://gist.github.com/cowboy/742952
-             * 
+             *
              */
             htmlDoc: function (html) {
                 var parent,
@@ -198,7 +198,7 @@
                 }
                 // Create the parent node and append the parsed, place-held HTML.
                 parent.html(htmlParsed);
-                
+
                 // Replace each placeholder element with its intended element.
                 $.each(elems, function(i) {
                     var elem = parent.find("#" + prefix + i).before(elems[i]);
@@ -214,12 +214,12 @@
              *
              * This is used to clear the "cache" object that stores
              * all of the html. This would prevent the client from
-             * running out of memory and allow the user to hit the 
+             * running out of memory and allow the user to hit the
              * server for a fresh copy of the content.
              *
              * @param   {object}    obj
              * @param   {number}    cap
-             * 
+             *
              */
             clearIfOverCapacity: function (obj, cap) {
                 // Polyfill Object.keys if it doesn"t exist
@@ -247,7 +247,7 @@
              * Finds the inner content of an element, by an ID, from a jQuery object
              * @param   {string}    id
              * @param   {object}    $html
-             * 
+             *
              */
             getContentById: function (id, $html) {
                 $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
@@ -262,7 +262,7 @@
              * @param   {object}    object - object contents will be stored into
              * @param   {string}    url - url to be used as the prop
              * @param   {jquery}    html - contents to store
-             * 
+             *
              */
             storePageIn: function (object, url, $html) {
                 $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
@@ -278,7 +278,7 @@
              * Triggers an "allanimationend" event when all animations are complete
              * @param   {object}    $element - jQuery object that should trigger event
              * @param   {string}    resetOn - which other events to trigger allanimationend on
-             * 
+             *
              */
              triggerAllAnimationEndEvent: function ($element, resetOn) {
 
@@ -316,7 +316,7 @@
             /** Forces browser to redraw elements */
             redraw: function ($element) {
                 $element.height(0);
-			    setTimeout(function(){$element.height("auto");}, 0);
+                setTimeout(function(){$element.height("auto");}, 0);
             }
         },
 
@@ -326,7 +326,7 @@
                 var url     = window.location.href,
                     $page   = $("#" + e.state.id),
                     page    = $page.data("smoothState");
-                
+
                 if(page.href !== url && !utility.isHash(url)) {
                     page.load(url, true);
                 }
@@ -338,23 +338,23 @@
             var
                 /** Container element smoothState is run on */
                 $container  = $(element),
-                
+
                 /** Variable that stores pages after they are requested */
                 cache       = {},
-                
+
                 /** Url of the content that is currently displayed */
                 currentHref = window.location.href,
 
                 /**
-                 * Loads the contents of a url into our container 
+                 * Loads the contents of a url into our container
                  *
                  * @param   {string}    url
                  * @param   {bool}      isPopped - used to determine if whe should
                  *                      add a new item into the history object
-                 * 
+                 *
                  */
                 load = function (url, isPopped) {
-                    
+
                     /** Makes this an optional variable by setting a default */
                     isPopped = isPopped || false;
 
@@ -363,7 +363,7 @@
                         hasRunCallback  = false,
 
                         callbBackEnded  = false,
-                        
+
                         /** List of responses for the states of the page request */
                         responses       = {
 
@@ -386,23 +386,23 @@
 
                             /** Loading, wait 10 ms and check again */
                             fetching: function() {
-                                
+
                                 if(!hasRunCallback) {
-                                    
+
                                     hasRunCallback = true;
-                                    
+
                                     // Run the onProgress callback and set trigger
                                     $container.one("ss.onStartEnd", function(){
                                         options.onProgress.render(url, $container, null);
-                                        
+
                                         setTimeout(function(){
                                             $container.trigger("ss.onProgressEnd");
                                             callbBackEnded = true;
                                         }, options.onStart.duration);
-                                    
+
                                     });
                                 }
-                                
+
                                 setTimeout(function () {
                                     // Might of been canceled, better check!
                                     if(cache.hasOwnProperty(url)){
@@ -416,11 +416,11 @@
                                 window.location = url;
                             }
                         };
-                    
+
                     if (!cache.hasOwnProperty(url)) {
                         fetch(url);
                     }
-                    
+
                     // Run the onStart callback and set trigger
                     options.onStart.render(url, $container, null);
                     setTimeout(function(){
@@ -440,9 +440,9 @@
 
                     if($content) {
                         document.title = cache[url].title;
-						utility.replaceHeadTags(cache[url].html, options.headTagSelectors);
+                        utility.replaceHeadTags(cache[url].html, options.headTagSelectors);
                         $container.data("smoothState").href = url;
-                        
+
                         // Call the onEnd callback and set trigger
                         options.onEnd.render(url, $container, $content);
 
@@ -466,7 +466,7 @@
                 /**
                  * Fetches the contents of a url and stores it in the "cache" varible
                  * @param   {string}    url
-                 * 
+                 *
                  */
                 fetch = function (url) {
 
@@ -476,7 +476,7 @@
                     }
 
                     cache = utility.clearIfOverCapacity(cache, options.pageCacheSize);
-                    
+
                     cache[url] = { status: "fetching" };
 
                     var requestUrl  = options.alterRequestUrl(url) || url,
@@ -498,7 +498,7 @@
                  * Binds to the hover event of a link, used for prefetching content
                  *
                  * @param   {object}    event
-                 * 
+                 *
                  */
                 hoverAnchor = function (event) {
                     var $anchor = $(event.currentTarget),
@@ -513,7 +513,7 @@
                  * Binds to the click event of a link, used to show the content
                  *
                  * @param   {object}    event
-                 * 
+                 *
                  */
                 clickAnchor = function (event) {
                     var $anchor     = $(event.currentTarget),
@@ -532,7 +532,7 @@
                  * Binds all events and inits functionality
                  *
                  * @param   {object}    event
-                 * 
+                 *
                  */
                 bindEventHandlers = function ($element) {
                     //@todo: Handle form submissions
@@ -547,9 +547,9 @@
                 /** Used to restart css animations with a class */
                 toggleAnimationClass = function (classname) {
                     var classes = $container.addClass(classname).prop("class");
-                    
+
                     $container.removeClass(classes);
-                    
+
                     setTimeout(function(){
                         $container.addClass(classes);
                     },0);
@@ -557,7 +557,7 @@
                     $container.one("ss.onStartEnd ss.onProgressEnd ss.onEndEnd", function(){
                         $container.removeClass(classname);
                     });
-                    
+
                 };
 
             /** Override defaults with options passed in */

--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -36,6 +36,12 @@
             /** The number of pages smoothState will try to store in memory and not request again */
             pageCacheSize : 0,
             
+            /** Meta tags which should be replaced by meta tags of requested page */
+	    metaTags: ['meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
+
+	    /** Link tags which should be replaced by link tags of requested page */
+	    linkTags: ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]'],
+            
             /** A function that can be used to alter urls before they are used to request content */
             alterRequestUrl : function (url) {
                 return url;
@@ -76,6 +82,54 @@
         
         /** Utility functions that are decoupled from SmoothState */
         utility     = {
+        	
+	   /**
+	    * Replace meta tags in current doc with tags from loaded doc
+	    * @param   {obj}       cache - cache object
+	    * @param   {string}    url - cache url
+	    * @param   {array}     metaTags - array of meta tag selectors
+	    *
+	    */
+	   replaceMetaTags: function (cache, url, metaTags) {
+
+		    var $cachedDoc = cache[url].html,
+			$currentDoc = $('html');
+
+		   if (metaTags.length > 0) {
+			   $(metaTags).each(function (key, value) {
+
+				   var metaTag = $cachedDoc.find(value);
+
+				   if (metaTag.length > 0) {
+					   $currentDoc.find(value).attr('content',metaTag.attr('content'));
+			   	   }
+			   });
+		   }
+	   },
+
+	   /**
+	    * Replace link tags in current doc with link from loaded doc
+	    * @param   {obj}       cache - cache object
+	    * @param   {string}    url - cache url
+	    * @param   {array}     linkTags - array of meta tag selectors
+	    *
+	    */
+	    replaceLinkTags: function (cache, url, linkTags) {
+
+		    var $cachedDoc = cache[url].html,
+			$currentDoc = $('html');
+
+		    if (linkTags.length > 0) {
+			    $(linkTags).each(function (key, value) {
+
+				    var linkTag = $cachedDoc.find(value);
+
+				    if (linkTag.length > 0) {
+					    $currentDoc.find(value).attr('href',linkTag.attr('href'));
+				    }
+			    });
+	    	    }
+	    },
 
             /**
              * Checks to see if the url is external
@@ -396,6 +450,8 @@
 
                     if($content) {
                         document.title = cache[url].title;
+                        utility.replaceMetaTags(cache, url, options.metaTags);
+			utility.replaceLinkTags(cache, url, options.linkTags);
                         $container.data('smoothState').href = url;
                         
                         // Call the onEnd callback and set trigger

--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -36,11 +36,8 @@
             /** The number of pages smoothState will try to store in memory and not request again */
             pageCacheSize : 0,
             
-            /** Meta tags which should be replaced by meta tags of requested page */
-	    metaTags: ['meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
-
-	    /** Link tags which should be replaced by link tags of requested page */
-	    linkTags: ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]'],
+            /** Head tags like meta or link which should be replaced by head tags of requested page */
+	    headTags : ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]','meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
             
             /** A function that can be used to alter urls before they are used to request content */
             alterRequestUrl : function (url) {
@@ -83,52 +80,45 @@
         /** Utility functions that are decoupled from SmoothState */
         utility     = {
         	
-	   /**
-	    * Replace meta tags in current doc with tags from loaded doc
-	    * @param   {obj}       cache - cache object
-	    * @param   {string}    url - cache url
-	    * @param   {array}     metaTags - array of meta tag selectors
-	    *
-	    */
-	   replaceMetaTags: function (cache, url, metaTags) {
+	    /**
+	     * Replace head tags in current doc with tags from loaded doc
+	     * @param   {obj}       cache - cache object
+	     * @param   {string}    url - cache url
+	     * @param   {array}     headTags - array of head tag selectors
+	     *
+	     */
+	    replaceHeadTags: function (cache, url, headTags) {
 
-		    var $cachedDoc = cache[url].html,
-			$currentDoc = $('html');
+		var $cachedDoc = cache[url].html,
+		    $currentDoc = $('html');
 
-		   if (metaTags.length > 0) {
-			   $(metaTags).each(function (key, value) {
+		if (headTags.length > 0) {
+			$(headTags).each(function (key, value) {
 
-				   var metaTag = $cachedDoc.find(value);
+				var headTag = $cachedDoc.find(value),
+				    headTagType = headTag.prop('tagName').toLowerCase(),
+				    headTagAttribute;
 
-				   if (metaTag.length > 0) {
-					   $currentDoc.find(value).attr('content',metaTag.attr('content'));
-			   	   }
-			   });
-		   }
-	   },
-
-	   /**
-	    * Replace link tags in current doc with link from loaded doc
-	    * @param   {obj}       cache - cache object
-	    * @param   {string}    url - cache url
-	    * @param   {array}     linkTags - array of meta tag selectors
-	    *
-	    */
-	    replaceLinkTags: function (cache, url, linkTags) {
-
-		    var $cachedDoc = cache[url].html,
-			$currentDoc = $('html');
-
-		    if (linkTags.length > 0) {
-			    $(linkTags).each(function (key, value) {
-
-				    var linkTag = $cachedDoc.find(value);
-
-				    if (linkTag.length > 0) {
-					    $currentDoc.find(value).attr('href',linkTag.attr('href'));
-				    }
-			    });
-	    	    }
+				if (headTag.length > 0) {
+					
+					switch(headTagType){
+						case 'link':
+							headTagAttribute = 'href';
+						break;
+						case 'meta':
+							headTagAttribute = 'content';
+						break;
+					}
+					
+					if(headTagAttribute.length > 0){
+						$currentDoc.find(value).attr(headTagAttribute,headTag.attr(headTagAttribute));
+					}
+					else {
+						consl.warn("Head tag of type '" + headTagType + "' not supported.");
+					}
+				}
+			});
+		}
 	    },
 
             /**

--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -1,85 +1,85 @@
 /**
  * smoothState.js is a jQuery plugin to stop page load jank.
  *
- * This jQuery plugin progressively enhances page loads to
+ * This jQuery plugin progressively enhances page loads to 
  * behave more like a single-page application.
  *
  * @author  Miguel Ángel Pérez   reachme@miguel-perez.com
  * @see     https://github.com/miguel-perez/jquery.smoothState.js
- *
+ * 
  */
 ;(function ( $, window, document, undefined ) {
-	"use strict";
+    "use strict";
 
-	var
-		/** Used later to scroll page to the top */
-			$body       = $("html, body"),
+    var
+        /** Used later to scroll page to the top */
+        $body       = $("html, body"),
+        
+        /** Used in development mode to console out useful warnings */
+        consl       = (window.console || false),
+        
+        /** Plugin default options */
+        defaults    = {
 
-		/** Used in development mode to console out useful warnings */
-			consl       = (window.console || false),
+            /** jquery element string to specify which anchors smoothstate should bind to */
+            anchors : "a",
 
-		/** Plugin default options */
-			defaults    = {
-
-			/** jquery element string to specify which anchors smoothstate should bind to */
-			anchors : "a",
-
-			/** If set to true, smoothState will prefetch a link's contents on hover */
-			prefetch : false,
-
-			/** A selecor that deinfes with links should be ignored by smoothState */
-			blacklist : ".no-smoothstate, [target]",
-
-			/** If set to true, smoothState will log useful debug information instead of aborting */
-			development : false,
-
-			/** The number of pages smoothState will try to store in memory and not request again */
-			pageCacheSize : 0,
-
+            /** If set to true, smoothState will prefetch a link's contents on hover */
+            prefetch : false,
+            
+            /** A selecor that deinfes with links should be ignored by smoothState */
+            blacklist : ".no-smoothstate, [target]",
+            
+            /** If set to true, smoothState will log useful debug information instead of aborting */
+            development : false,
+            
+            /** The number of pages smoothState will try to store in memory and not request again */
+            pageCacheSize : 0,
+			
 			/** An array of selectors that defines head tags which should be replaced by the head tags of requested page. Meta and link tags are supported */
 			headTagSelectors : ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]','meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
+            
+            /** A function that can be used to alter urls before they are used to request content */
+            alterRequestUrl : function (url) {
+                return url;
+            },
+            
+            /** Run when a link has been activated */
+            onStart : {
+                duration: 0,
+                render: function (url, $container) {
+                    $body.scrollTop(0);
+                }
+            },
 
-			/** A function that can be used to alter urls before they are used to request content */
-			alterRequestUrl : function (url) {
-				return url;
-			},
+            /** Run if the page request is still pending and onStart has finished animating */
+            onProgress : {
+                duration: 0,
+                render: function (url, $container) {
+                    $body.css("cursor", "wait");
+                    $body.find("a").css("cursor", "wait");
+                }
+            },
 
-			/** Run when a link has been activated */
-			onStart : {
-				duration: 0,
-				render: function (url, $container) {
-					$body.scrollTop(0);
-				}
-			},
+            /** Run when requested content is ready to be injected into the page  */
+            onEnd : {
+                duration: 0,
+                render: function (url, $container, $content) {
+                    $body.css("cursor", "auto");
+                    $body.find("a").css("cursor", "auto");
+                    $container.html($content);
+                }
+            },
 
-			/** Run if the page request is still pending and onStart has finished animating */
-			onProgress : {
-				duration: 0,
-				render: function (url, $container) {
-					$body.css("cursor", "wait");
-					$body.find("a").css("cursor", "wait");
-				}
-			},
+            /** Run when content has been injected and all animations are complete  */
+            callback : function(url, $container, $content) {
 
-			/** Run when requested content is ready to be injected into the page  */
-			onEnd : {
-				duration: 0,
-				render: function (url, $container, $content) {
-					$body.css("cursor", "auto");
-					$body.find("a").css("cursor", "auto");
-					$container.html($content);
-				}
-			},
-
-			/** Run when content has been injected and all animations are complete  */
-			callback : function(url, $container, $content) {
-
-			}
-		},
-
-		/** Utility functions that are decoupled from SmoothState */
-		utility     = {
-
+            }
+        },
+        
+        /** Utility functions that are decoupled from SmoothState */
+        utility     = {
+		
 			/**
 			 * Replace head tags in current doc with tags from loaded doc
 			 * @param   {obj}       cachedDoc - cached document
@@ -104,13 +104,13 @@
 						switch(headTagType){
 							case "link":
 								headTagAttribute = "href";
-								break;
+							break;
 							case "meta":
 								headTagAttribute = "content";
-								break;
+							break;
 							default:
 								headTagAttribute = false;
-								break;
+							break;
 						}
 
 						if(headTagAttribute){
@@ -121,493 +121,493 @@
 				});
 			},
 
-			/**
-			 * Checks to see if the url is external
-			 * @param   {string}    url - url being evaluated
-			 * @see     http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
-			 *
-			 */
-			isExternal: function (url) {
-				var match = url.match(/^([^:\/?#]+:)?(?:\/\/([^\/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/);
-				if (typeof match[1] === "string" && match[1].length > 0 && match[1].toLowerCase() !== window.location.protocol) {
-					return true;
-				}
-				if (typeof match[2] === "string" && match[2].length > 0 && match[2].replace(new RegExp(":(" + {"http:": 80, "https:": 443}[window.location.protocol] + ")?$"), "") !== window.location.host) {
-					return true;
-				}
-				return false;
-			},
+            /**
+             * Checks to see if the url is external
+             * @param   {string}    url - url being evaluated
+             * @see     http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
+             * 
+             */
+            isExternal: function (url) {
+                var match = url.match(/^([^:\/?#]+:)?(?:\/\/([^\/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/);
+                if (typeof match[1] === "string" && match[1].length > 0 && match[1].toLowerCase() !== window.location.protocol) {
+                    return true;
+                }
+                if (typeof match[2] === "string" && match[2].length > 0 && match[2].replace(new RegExp(":(" + {"http:": 80, "https:": 443}[window.location.protocol] + ")?$"), "") !== window.location.host) {
+                    return true;
+                }
+                return false;
+            },
 
-			/**
-			 * Checks to see if the url is an internal hash
-			 * @param   {string}    url - url being evaluated
-			 *
-			 */
-			isHash: function (url) {
-				var hasPathname = (url.indexOf(window.location.pathname) > 0) ? true : false,
-					hasHash = (url.indexOf("#") > 0) ? true : false;
-				return (hasPathname && hasHash) ? true : false;
-			},
+            /**
+             * Checks to see if the url is an internal hash
+             * @param   {string}    url - url being evaluated
+             * 
+             */
+            isHash: function (url) {
+                var hasPathname = (url.indexOf(window.location.pathname) > 0) ? true : false,
+                    hasHash = (url.indexOf("#") > 0) ? true : false;
+                return (hasPathname && hasHash) ? true : false;
+            },
 
-			/**
-			 * Checks to see if we should be loading this URL
-			 * @param   {string}    url - url being evaluated
-			 * @param   {string}    blacklist - jquery selector
-			 *
-			 */
-			shouldLoad: function ($anchor, blacklist) {
-				var url = $anchor.prop("href");
-				// URL will only be loaded if it"s not an external link, hash, or blacklisted
-				return (!utility.isExternal(url) && !utility.isHash(url) && !$anchor.is(blacklist));
-			},
+            /**
+             * Checks to see if we should be loading this URL
+             * @param   {string}    url - url being evaluated
+             * @param   {string}    blacklist - jquery selector
+             * 
+             */
+            shouldLoad: function ($anchor, blacklist) {
+                var url = $anchor.prop("href");
+                // URL will only be loaded if it"s not an external link, hash, or blacklisted
+                return (!utility.isExternal(url) && !utility.isHash(url) && !$anchor.is(blacklist));
+            },
 
-			/**
-			 * Prevents jQuery from stripping elements from $(html)
-			 * @param   {string}    url - url being evaluated
-			 * @author  Ben Alman   http://benalman.com/
-			 * @see     https://gist.github.com/cowboy/742952
-			 *
-			 */
-			htmlDoc: function (html) {
-				var parent,
-					elems       = $(),
-					matchTag    = /<(\/?)(html|head|body|title|base|meta)(\s+[^>]*)?>/ig,
-					prefix      = "ss" + Math.round(Math.random() * 100000),
-					htmlParsed  = html.replace(matchTag, function(tag, slash, name, attrs) {
-						var obj = {};
-						if (!slash) {
-							$.merge(elems, $("<" + name + "/>"));
-							if (attrs) {
-								$.each($("<div" + attrs + "/>")[0].attributes, function(i, attr) {
-									obj[attr.name] = attr.value;
-								});
-							}
-							elems.eq(-1).attr(obj);
-						}
-						return "<" + slash + "div" + (slash ? "" : " id='" + prefix + (elems.length - 1) + "'") + ">";
-					});
+            /**
+             * Prevents jQuery from stripping elements from $(html)
+             * @param   {string}    url - url being evaluated
+             * @author  Ben Alman   http://benalman.com/
+             * @see     https://gist.github.com/cowboy/742952
+             * 
+             */
+            htmlDoc: function (html) {
+                var parent,
+                    elems       = $(),
+                    matchTag    = /<(\/?)(html|head|body|title|base|meta)(\s+[^>]*)?>/ig,
+                    prefix      = "ss" + Math.round(Math.random() * 100000),
+                    htmlParsed  = html.replace(matchTag, function(tag, slash, name, attrs) {
+                        var obj = {};
+                        if (!slash) {
+                            $.merge(elems, $("<" + name + "/>"));
+                            if (attrs) {
+                                $.each($("<div" + attrs + "/>")[0].attributes, function(i, attr) {
+                                obj[attr.name] = attr.value;
+                                });
+                            }
+                            elems.eq(-1).attr(obj);
+                        }
+                        return "<" + slash + "div" + (slash ? "" : " id='" + prefix + (elems.length - 1) + "'") + ">";
+                    });
 
-				// If no placeholder elements were necessary, just return normal
-				// jQuery-parsed HTML.
-				if (!elems.length) {
-					return $(html);
-				}
-				// Create parent node if it hasn"t been created yet.
-				if (!parent) {
-					parent = $("<div/>");
-				}
-				// Create the parent node and append the parsed, place-held HTML.
-				parent.html(htmlParsed);
+                // If no placeholder elements were necessary, just return normal
+                // jQuery-parsed HTML.
+                if (!elems.length) {
+                    return $(html);
+                }
+                // Create parent node if it hasn"t been created yet.
+                if (!parent) {
+                    parent = $("<div/>");
+                }
+                // Create the parent node and append the parsed, place-held HTML.
+                parent.html(htmlParsed);
+                
+                // Replace each placeholder element with its intended element.
+                $.each(elems, function(i) {
+                    var elem = parent.find("#" + prefix + i).before(elems[i]);
+                    elems.eq(i).html(elem.contents());
+                    elem.remove();
+                });
 
-				// Replace each placeholder element with its intended element.
-				$.each(elems, function(i) {
-					var elem = parent.find("#" + prefix + i).before(elems[i]);
-					elems.eq(i).html(elem.contents());
-					elem.remove();
-				});
+                return parent.children().unwrap();
+            },
 
-				return parent.children().unwrap();
-			},
+            /**
+             * Resets an object if it has too many properties
+             *
+             * This is used to clear the "cache" object that stores
+             * all of the html. This would prevent the client from
+             * running out of memory and allow the user to hit the 
+             * server for a fresh copy of the content.
+             *
+             * @param   {object}    obj
+             * @param   {number}    cap
+             * 
+             */
+            clearIfOverCapacity: function (obj, cap) {
+                // Polyfill Object.keys if it doesn"t exist
+                if (!Object.keys) {
+                    Object.keys = function (obj) {
+                        var keys = [],
+                            k;
+                        for (k in obj) {
+                            if (Object.prototype.hasOwnProperty.call(obj, k)) {
+                                keys.push(k);
+                            }
+                        }
+                        return keys;
+                    };
+                }
 
-			/**
-			 * Resets an object if it has too many properties
-			 *
-			 * This is used to clear the "cache" object that stores
-			 * all of the html. This would prevent the client from
-			 * running out of memory and allow the user to hit the
-			 * server for a fresh copy of the content.
-			 *
-			 * @param   {object}    obj
-			 * @param   {number}    cap
-			 *
-			 */
-			clearIfOverCapacity: function (obj, cap) {
-				// Polyfill Object.keys if it doesn"t exist
-				if (!Object.keys) {
-					Object.keys = function (obj) {
-						var keys = [],
-							k;
-						for (k in obj) {
-							if (Object.prototype.hasOwnProperty.call(obj, k)) {
-								keys.push(k);
-							}
-						}
-						return keys;
-					};
-				}
+                if (Object.keys(obj).length > cap) {
+                    obj = {};
+                }
 
-				if (Object.keys(obj).length > cap) {
-					obj = {};
-				}
+                return obj;
+            },
 
-				return obj;
-			},
+            /**
+             * Finds the inner content of an element, by an ID, from a jQuery object
+             * @param   {string}    id
+             * @param   {object}    $html
+             * 
+             */
+            getContentById: function (id, $html) {
+                $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
+                var $insideElem         = $html.find(id),
+                    updatedContainer    = ($insideElem.length) ? $.trim($insideElem.html()) : $html.filter(id).html(),
+                    newContent          = (updatedContainer.length) ? $(updatedContainer) : null;
+                return newContent;
+            },
 
-			/**
-			 * Finds the inner content of an element, by an ID, from a jQuery object
-			 * @param   {string}    id
-			 * @param   {object}    $html
-			 *
-			 */
-			getContentById: function (id, $html) {
-				$html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
-				var $insideElem         = $html.find(id),
-					updatedContainer    = ($insideElem.length) ? $.trim($insideElem.html()) : $html.filter(id).html(),
-					newContent          = (updatedContainer.length) ? $(updatedContainer) : null;
-				return newContent;
-			},
+            /**
+             * Stores html content as jquery object in given object
+             * @param   {object}    object - object contents will be stored into
+             * @param   {string}    url - url to be used as the prop
+             * @param   {jquery}    html - contents to store
+             * 
+             */
+            storePageIn: function (object, url, $html) {
+                $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
+                object[url] = { // Content is indexed by the url
+                    status: "loaded",
+                    title: $html.find("title").text(), // Stores the title of the page
+                    html: $html // Stores the contents of the page
+                };
+                return object;
+            },
 
-			/**
-			 * Stores html content as jquery object in given object
-			 * @param   {object}    object - object contents will be stored into
-			 * @param   {string}    url - url to be used as the prop
-			 * @param   {jquery}    html - contents to store
-			 *
-			 */
-			storePageIn: function (object, url, $html) {
-				$html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
-				object[url] = { // Content is indexed by the url
-					status: "loaded",
-					title: $html.find("title").text(), // Stores the title of the page
-					html: $html // Stores the contents of the page
-				};
-				return object;
-			},
+            /**
+             * Triggers an "allanimationend" event when all animations are complete
+             * @param   {object}    $element - jQuery object that should trigger event
+             * @param   {string}    resetOn - which other events to trigger allanimationend on
+             * 
+             */
+             triggerAllAnimationEndEvent: function ($element, resetOn) {
 
-			/**
-			 * Triggers an "allanimationend" event when all animations are complete
-			 * @param   {object}    $element - jQuery object that should trigger event
-			 * @param   {string}    resetOn - which other events to trigger allanimationend on
-			 *
-			 */
-			triggerAllAnimationEndEvent: function ($element, resetOn) {
+                resetOn = " " + resetOn || "";
 
-				resetOn = " " + resetOn || "";
+                var animationCount      = 0,
+                    animationstart      = "animationstart webkitAnimationStart oanimationstart MSAnimationStart",
+                    animationend        = "animationend webkitAnimationEnd oanimationend MSAnimationEnd",
+                    eventname           = "allanimationend",
+                    onAnimationStart    = function (e) {
+                        if ($(e.delegateTarget).is($element)) {
+                            e.stopPropagation();
+                            animationCount ++;
+                        }
+                    },
+                    onAnimationEnd      = function (e) {
+                        if ($(e.delegateTarget).is($element)) {
+                            e.stopPropagation();
+                            animationCount --;
+                            if(animationCount === 0) {
+                                $element.trigger(eventname);
+                            }
+                        }
+                    };
 
-				var animationCount      = 0,
-					animationstart      = "animationstart webkitAnimationStart oanimationstart MSAnimationStart",
-					animationend        = "animationend webkitAnimationEnd oanimationend MSAnimationEnd",
-					eventname           = "allanimationend",
-					onAnimationStart    = function (e) {
-						if ($(e.delegateTarget).is($element)) {
-							e.stopPropagation();
-							animationCount ++;
-						}
-					},
-					onAnimationEnd      = function (e) {
-						if ($(e.delegateTarget).is($element)) {
-							e.stopPropagation();
-							animationCount --;
-							if(animationCount === 0) {
-								$element.trigger(eventname);
-							}
-						}
-					};
+                $element.on(animationstart, onAnimationStart);
+                $element.on(animationend, onAnimationEnd);
 
-				$element.on(animationstart, onAnimationStart);
-				$element.on(animationend, onAnimationEnd);
+                $element.on("allanimationend" + resetOn, function(){
+                    animationCount = 0;
+                    utility.redraw($element);
+                });
+            },
 
-				$element.on("allanimationend" + resetOn, function(){
-					animationCount = 0;
-					utility.redraw($element);
-				});
-			},
+            /** Forces browser to redraw elements */
+            redraw: function ($element) {
+                $element.height(0);
+			    setTimeout(function(){$element.height("auto");}, 0);
+            }
+        },
 
-			/** Forces browser to redraw elements */
-			redraw: function ($element) {
-				$element.height(0);
-				setTimeout(function(){$element.height("auto");}, 0);
-			}
-		},
+        /** Handles the popstate event, like when the user hits "back" */
+        onPopState = function ( e ) {
+            if(e.state !== null) {
+                var url     = window.location.href,
+                    $page   = $("#" + e.state.id),
+                    page    = $page.data("smoothState");
+                
+                if(page.href !== url && !utility.isHash(url)) {
+                    page.load(url, true);
+                }
+            }
+        },
 
-		/** Handles the popstate event, like when the user hits "back" */
-			onPopState = function ( e ) {
-			if(e.state !== null) {
-				var url     = window.location.href,
-					$page   = $("#" + e.state.id),
-					page    = $page.data("smoothState");
+        /** Constructor function */
+        SmoothState = function ( element, options ) {
+            var
+                /** Container element smoothState is run on */
+                $container  = $(element),
+                
+                /** Variable that stores pages after they are requested */
+                cache       = {},
+                
+                /** Url of the content that is currently displayed */
+                currentHref = window.location.href,
 
-				if(page.href !== url && !utility.isHash(url)) {
-					page.load(url, true);
-				}
-			}
-		},
+                /**
+                 * Loads the contents of a url into our container 
+                 *
+                 * @param   {string}    url
+                 * @param   {bool}      isPopped - used to determine if whe should
+                 *                      add a new item into the history object
+                 * 
+                 */
+                load = function (url, isPopped) {
+                    
+                    /** Makes this an optional variable by setting a default */
+                    isPopped = isPopped || false;
 
-		/** Constructor function */
-			SmoothState = function ( element, options ) {
-			var
-				/** Container element smoothState is run on */
-					$container  = $(element),
+                    var
+                        /** Used to check if the onProgress function has been run */
+                        hasRunCallback  = false,
 
-				/** Variable that stores pages after they are requested */
-					cache       = {},
+                        callbBackEnded  = false,
+                        
+                        /** List of responses for the states of the page request */
+                        responses       = {
 
-				/** Url of the content that is currently displayed */
-					currentHref = window.location.href,
+                            /** Page is ready, update the content */
+                            loaded: function() {
+                                var eventName = hasRunCallback ? "ss.onProgressEnd" : "ss.onStartEnd";
 
-				/**
-				 * Loads the contents of a url into our container
-				 *
-				 * @param   {string}    url
-				 * @param   {bool}      isPopped - used to determine if whe should
-				 *                      add a new item into the history object
-				 *
-				 */
-					load = function (url, isPopped) {
+                                if(!callbBackEnded || !hasRunCallback) {
+                                    $container.one(eventName, function(){
+                                        updateContent(url);
+                                    });
+                                } else if(callbBackEnded) {
+                                    updateContent(url);
+                                }
 
-					/** Makes this an optional variable by setting a default */
-					isPopped = isPopped || false;
+                                if(!isPopped) {
+                                    window.history.pushState({ id: $container.prop("id") }, cache[url].title, url);
+                                }
+                            },
 
-					var
-						/** Used to check if the onProgress function has been run */
-							hasRunCallback  = false,
+                            /** Loading, wait 10 ms and check again */
+                            fetching: function() {
+                                
+                                if(!hasRunCallback) {
+                                    
+                                    hasRunCallback = true;
+                                    
+                                    // Run the onProgress callback and set trigger
+                                    $container.one("ss.onStartEnd", function(){
+                                        options.onProgress.render(url, $container, null);
+                                        
+                                        setTimeout(function(){
+                                            $container.trigger("ss.onProgressEnd");
+                                            callbBackEnded = true;
+                                        }, options.onStart.duration);
+                                    
+                                    });
+                                }
+                                
+                                setTimeout(function () {
+                                    // Might of been canceled, better check!
+                                    if(cache.hasOwnProperty(url)){
+                                        responses[cache[url].status]();
+                                    }
+                                }, 10);
+                            },
 
-						callbBackEnded  = false,
+                            /** Error, abort and redirect */
+                            error: function(){
+                                window.location = url;
+                            }
+                        };
+                    
+                    if (!cache.hasOwnProperty(url)) {
+                        fetch(url);
+                    }
+                    
+                    // Run the onStart callback and set trigger
+                    options.onStart.render(url, $container, null);
+                    setTimeout(function(){
+                        $container.trigger("ss.onStartEnd");
+                    }, options.onStart.duration);
 
-						/** List of responses for the states of the page request */
-							responses       = {
+                    // Start checking for the status of content
+                    responses[cache[url].status]();
 
-							/** Page is ready, update the content */
-							loaded: function() {
-								var eventName = hasRunCallback ? "ss.onProgressEnd" : "ss.onStartEnd";
+                },
 
-								if(!callbBackEnded || !hasRunCallback) {
-									$container.one(eventName, function(){
-										updateContent(url);
-									});
-								} else if(callbBackEnded) {
-									updateContent(url);
-								}
+                /** Updates the contents from cache[url] */
+                updateContent = function (url) {
+                    // If the content has been requested and is done:
+                    var containerId = "#" + $container.prop("id"),
+                        $content    = cache[url] ? utility.getContentById(containerId, cache[url].html) : null;
 
-								if(!isPopped) {
-									window.history.pushState({ id: $container.prop("id") }, cache[url].title, url);
-								}
-							},
-
-							/** Loading, wait 10 ms and check again */
-							fetching: function() {
-
-								if(!hasRunCallback) {
-
-									hasRunCallback = true;
-
-									// Run the onProgress callback and set trigger
-									$container.one("ss.onStartEnd", function(){
-										options.onProgress.render(url, $container, null);
-
-										setTimeout(function(){
-											$container.trigger("ss.onProgressEnd");
-											callbBackEnded = true;
-										}, options.onStart.duration);
-
-									});
-								}
-
-								setTimeout(function () {
-									// Might of been canceled, better check!
-									if(cache.hasOwnProperty(url)){
-										responses[cache[url].status]();
-									}
-								}, 10);
-							},
-
-							/** Error, abort and redirect */
-							error: function(){
-								window.location = url;
-							}
-						};
-
-					if (!cache.hasOwnProperty(url)) {
-						fetch(url);
-					}
-
-					// Run the onStart callback and set trigger
-					options.onStart.render(url, $container, null);
-					setTimeout(function(){
-						$container.trigger("ss.onStartEnd");
-					}, options.onStart.duration);
-
-					// Start checking for the status of content
-					responses[cache[url].status]();
-
-				},
-
-				/** Updates the contents from cache[url] */
-					updateContent = function (url) {
-					// If the content has been requested and is done:
-					var containerId = "#" + $container.prop("id"),
-						$content    = cache[url] ? utility.getContentById(containerId, cache[url].html) : null;
-
-					if($content) {
-						document.title = cache[url].title;
+                    if($content) {
+                        document.title = cache[url].title;
 						utility.replaceHeadTags(cache[url].html, options.headTagSelectors);
-						$container.data("smoothState").href = url;
+                        $container.data("smoothState").href = url;
+                        
+                        // Call the onEnd callback and set trigger
+                        options.onEnd.render(url, $container, $content);
 
-						// Call the onEnd callback and set trigger
-						options.onEnd.render(url, $container, $content);
+                        $container.one("ss.onEndEnd", function(){
+                            options.callback(url, $container, $content);
+                        });
 
-						$container.one("ss.onEndEnd", function(){
-							options.callback(url, $container, $content);
-						});
+                        setTimeout(function(){
+                            $container.trigger("ss.onEndEnd");
+                        }, options.onEnd.duration);
 
-						setTimeout(function(){
-							$container.trigger("ss.onEndEnd");
-						}, options.onEnd.duration);
+                    } else if (!$content && options.development && consl) {
+                        // Throw warning to help debug in development mode
+                        consl.warn("No element with an id of " + containerId + " in response from " + url + " in " + cache);
+                    } else {
+                        // No content availble to update with, aborting...
+                        window.location = url;
+                    }
+                },
 
-					} else if (!$content && options.development && consl) {
-						// Throw warning to help debug in development mode
-						consl.warn("No element with an id of " + containerId + " in response from " + url + " in " + cache);
-					} else {
-						// No content availble to update with, aborting...
-						window.location = url;
-					}
-				},
+                /**
+                 * Fetches the contents of a url and stores it in the "cache" varible
+                 * @param   {string}    url
+                 * 
+                 */
+                fetch = function (url) {
 
-				/**
-				 * Fetches the contents of a url and stores it in the "cache" varible
-				 * @param   {string}    url
-				 *
-				 */
-					fetch = function (url) {
+                    // Don"t fetch we have the content already
+                    if(cache.hasOwnProperty(url)) {
+                        return;
+                    }
 
-					// Don"t fetch we have the content already
-					if(cache.hasOwnProperty(url)) {
-						return;
-					}
+                    cache = utility.clearIfOverCapacity(cache, options.pageCacheSize);
+                    
+                    cache[url] = { status: "fetching" };
 
-					cache = utility.clearIfOverCapacity(cache, options.pageCacheSize);
+                    var requestUrl  = options.alterRequestUrl(url) || url,
+                        request     = $.ajax(requestUrl);
 
-					cache[url] = { status: "fetching" };
+                    // Store contents in cache variable if successful
+                    request.success(function (html) {
+                        // Clear cache varible if it"s getting too big
+                        utility.storePageIn(cache, url, html);
+                        $container.data("smoothState").cache = cache;
+                    });
 
-					var requestUrl  = options.alterRequestUrl(url) || url,
-						request     = $.ajax(requestUrl);
+                    // Mark as error
+                    request.error(function () {
+                        cache[url].status = "error";
+                    });
+                },
+                /**
+                 * Binds to the hover event of a link, used for prefetching content
+                 *
+                 * @param   {object}    event
+                 * 
+                 */
+                hoverAnchor = function (event) {
+                    var $anchor = $(event.currentTarget),
+                        url     = $anchor.prop("href");
+                    if (utility.shouldLoad($anchor, options.blacklist)) {
+                        event.stopPropagation();
+                        fetch(url);
+                    }
+                },
 
-					// Store contents in cache variable if successful
-					request.success(function (html) {
-						// Clear cache varible if it"s getting too big
-						utility.storePageIn(cache, url, html);
-						$container.data("smoothState").cache = cache;
-					});
+                /**
+                 * Binds to the click event of a link, used to show the content
+                 *
+                 * @param   {object}    event
+                 * 
+                 */
+                clickAnchor = function (event) {
+                    var $anchor     = $(event.currentTarget),
+                        url         = $anchor.prop("href");
 
-					// Mark as error
-					request.error(function () {
-						cache[url].status = "error";
-					});
-				},
-				/**
-				 * Binds to the hover event of a link, used for prefetching content
-				 *
-				 * @param   {object}    event
-				 *
-				 */
-					hoverAnchor = function (event) {
-					var $anchor = $(event.currentTarget),
-						url     = $anchor.prop("href");
-					if (utility.shouldLoad($anchor, options.blacklist)) {
-						event.stopPropagation();
-						fetch(url);
-					}
-				},
+                    // Ctrl (or Cmd) + click must open a new tab
+                    if (!event.metaKey && !event.ctrlKey && utility.shouldLoad($anchor, options.blacklist)) {
+                        // stopPropagation so that event doesn"t fire on parent containers.
+                        event.stopPropagation();
+                        event.preventDefault();
+                        load(url);
+                    }
+                },
 
-				/**
-				 * Binds to the click event of a link, used to show the content
-				 *
-				 * @param   {object}    event
-				 *
-				 */
-					clickAnchor = function (event) {
-					var $anchor     = $(event.currentTarget),
-						url         = $anchor.prop("href");
+                /**
+                 * Binds all events and inits functionality
+                 *
+                 * @param   {object}    event
+                 * 
+                 */
+                bindEventHandlers = function ($element) {
+                    //@todo: Handle form submissions
+                    $element.on("click", options.anchors, clickAnchor);
 
-					// Ctrl (or Cmd) + click must open a new tab
-					if (!event.metaKey && !event.ctrlKey && utility.shouldLoad($anchor, options.blacklist)) {
-						// stopPropagation so that event doesn"t fire on parent containers.
-						event.stopPropagation();
-						event.preventDefault();
-						load(url);
-					}
-				},
+                    if (options.prefetch) {
+                        $element.on("mouseover touchstart", options.anchors, hoverAnchor);
+                    }
 
-				/**
-				 * Binds all events and inits functionality
-				 *
-				 * @param   {object}    event
-				 *
-				 */
-					bindEventHandlers = function ($element) {
-					//@todo: Handle form submissions
-					$element.on("click", options.anchors, clickAnchor);
+                },
 
-					if (options.prefetch) {
-						$element.on("mouseover touchstart", options.anchors, hoverAnchor);
-					}
+                /** Used to restart css animations with a class */
+                toggleAnimationClass = function (classname) {
+                    var classes = $container.addClass(classname).prop("class");
+                    
+                    $container.removeClass(classes);
+                    
+                    setTimeout(function(){
+                        $container.addClass(classes);
+                    },0);
 
-				},
+                    $container.one("ss.onStartEnd ss.onProgressEnd ss.onEndEnd", function(){
+                        $container.removeClass(classname);
+                    });
+                    
+                };
 
-				/** Used to restart css animations with a class */
-					toggleAnimationClass = function (classname) {
-					var classes = $container.addClass(classname).prop("class");
+            /** Override defaults with options passed in */
+            options = $.extend(defaults, options);
 
-					$container.removeClass(classes);
+            /** Sets a default state */
+            if(window.history.state === null) {
+                window.history.replaceState({ id: $container.prop("id") }, document.title, currentHref);
+            }
 
-					setTimeout(function(){
-						$container.addClass(classes);
-					},0);
+            /** Stores the current page in cache variable */
+            utility.storePageIn(cache, currentHref, document.documentElement.outerHTML);
 
-					$container.one("ss.onStartEnd ss.onProgressEnd ss.onEndEnd", function(){
-						$container.removeClass(classname);
-					});
+            /** Bind all of the event handlers on the container, not anchors */
+            utility.triggerAllAnimationEndEvent($container, "ss.onStartEnd ss.onProgressEnd ss.onEndEnd");
 
-				};
+            /** Bind all of the event handlers on the container, not anchors */
+            bindEventHandlers($container);
 
-			/** Override defaults with options passed in */
-			options = $.extend(defaults, options);
+            /** Public methods */
+            return {
+                href: currentHref,
+                cache: cache,
+                load: load,
+                fetch: fetch,
+                toggleAnimationClass: toggleAnimationClass
+            };
+        },
 
-			/** Sets a default state */
-			if(window.history.state === null) {
-				window.history.replaceState({ id: $container.prop("id") }, document.title, currentHref);
-			}
+        /** Returns elements with SmoothState attached to it */
+        declareSmoothState = function ( options ) {
+            return this.each(function () {
+                // Checks to make sure the smoothState element has an id and isn"t already bound
+                if(this.id && !$.data(this, "smoothState")) {
+                    // Makes public methods available via $("element").data("smoothState");
+                    $.data(this, "smoothState", new SmoothState(this, options));
+                } else if (!this.id && consl) {
+                    // Throw warning if in development mode
+                    consl.warn("Every smoothState container needs an id but the following one does not have one:", this);
+                }
+            });
+        };
 
-			/** Stores the current page in cache variable */
-			utility.storePageIn(cache, currentHref, document.documentElement.outerHTML);
+    /** Sets the popstate function */
+    window.onpopstate = onPopState;
 
-			/** Bind all of the event handlers on the container, not anchors */
-			utility.triggerAllAnimationEndEvent($container, "ss.onStartEnd ss.onProgressEnd ss.onEndEnd");
+    /** Makes utility functions public for unit tests */
+    $.smoothStateUtility = utility;
 
-			/** Bind all of the event handlers on the container, not anchors */
-			bindEventHandlers($container);
-
-			/** Public methods */
-			return {
-				href: currentHref,
-				cache: cache,
-				load: load,
-				fetch: fetch,
-				toggleAnimationClass: toggleAnimationClass
-			};
-		},
-
-		/** Returns elements with SmoothState attached to it */
-			declareSmoothState = function ( options ) {
-			return this.each(function () {
-				// Checks to make sure the smoothState element has an id and isn"t already bound
-				if(this.id && !$.data(this, "smoothState")) {
-					// Makes public methods available via $("element").data("smoothState");
-					$.data(this, "smoothState", new SmoothState(this, options));
-				} else if (!this.id && consl) {
-					// Throw warning if in development mode
-					consl.warn("Every smoothState container needs an id but the following one does not have one:", this);
-				}
-			});
-		};
-
-	/** Sets the popstate function */
-	window.onpopstate = onPopState;
-
-	/** Makes utility functions public for unit tests */
-	$.smoothStateUtility = utility;
-
-	/** Defines the smoothState plugin */
-	$.fn.smoothState = declareSmoothState;
+    /** Defines the smoothState plugin */
+    $.fn.smoothState = declareSmoothState;
 
 })(jQuery, window, document);

--- a/tests/index.html
+++ b/tests/index.html
@@ -4,6 +4,12 @@
 	<meta charset="utf-8">
 	<title>QUnit $.smoothStateUtility() tests</title>
 	<link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.14.0.css">
+
+	<!-- START: Part of Tests, see: replaceHeadTags -->
+	<link rel="image_src" href="Image 1">
+	<meta name="description" content="Description for QUnit $.smoothStateUtility() tests">
+	<meta property="og:description" content="Open Graph Description for QUnit $.smoothStateUtility() tests">
+	<!-- END: Part of Tests, see: replaceHeadTags -->
 </head>
 <body>
 	<div id="qunit"></div>

--- a/tests/smoothStateUtilityTests.js
+++ b/tests/smoothStateUtilityTests.js
@@ -144,6 +144,20 @@ QUnit.test( "smoothStateUtility: triggerAllAnimationEndEvent", function( assert 
     assert.ok( triggered, "allanimationend fired" );
 });
 
+/**
+ * Replace head tags in current doc with tags from loaded doc
+ */
+QUnit.test( "smoothStateUtility: replaceHeadTags", function( assert ) {
+    var headTagSelectors = ['link[rel="canonical"]','link[rel="image_src"]','link[rel="publisher"]','meta[name="description"]','meta[name="keywords"]','meta[name="author"]','meta[name="publisher"]','meta[name="copyright"]','meta[property="og:title"]','meta[property="og:locale"]','meta[property="og:type"]','meta[property="og:site_name"]','meta[property="og:description"]','meta[property="og:image"]','meta[property="og:url"]','meta[name="robots"]'],
+        title            = "Test title " + Math.random(),
+        tags             = ['<link rel="image_src" href="replaceHeadTags Test 1">','<meta name="description" content="replaceHeadTags Test 2">','<meta property="og:description" content="replaceHeadTags Test 3">'],
+        cachedDoc        = $.smoothStateUtility.htmlDoc('<!doctype html> <html> <head> <title>' + title + '</title> ' + tags[0] + tags[1] + tags[2] + ' </head> <body id="main"> <div> Content </div> </body> </html>'),
+        currentDoc       = $('head');
 
+    $.smoothStateUtility.replaceHeadTags(cachedDoc,headTagSelectors);
 
-
+    // Should find new tags in current doc head
+    assert.ok( currentDoc.find(headTagSelectors[1]).attr("href") === "replaceHeadTags Test 1", "Tag 1 of 3 was replaced!" );
+    assert.ok( currentDoc.find(headTagSelectors[3]).attr("content") === "replaceHeadTags Test 2", "Tag 2 of 3 was replaced!" );
+    assert.ok( currentDoc.find(headTagSelectors[12]).attr("content") === "replaceHeadTags Test 3", "Tag 3 of 3 was replaced!" );
+});


### PR DESCRIPTION
This update replaces meta and link tags of the active document if its "body"-content is replaced by the cached "body"-content. 

There are to new default options for this, metaTags and linkTags. So you can define your own tags.

What do you think about this?
