### PR TITLE
#45 Fix ordering bug with add function on WebKit

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -132,7 +132,7 @@
                     htmlParsed  = html.replace(matchTag, function(tag, slash, name, attrs) {
                         var obj = {};
                         if (!slash) {
-                            elems = elems.add("<" + name + "/>");
+                            $.merge(elems, $("<" + name + "/>"));
                             if (attrs) {
                                 $.each($("<div" + attrs + "/>")[0].attributes, function(i, attr) {
                                 obj[attr.name] = attr.value;


### PR DESCRIPTION
The function `htmlDoc` need to keep the order in `elems`.
But in JQuery, there's a bug with `add` and the order. (https://github.com/jquery/api.jquery.com/issues/254 or http://bugs.jquery.com/ticket/13331)

A solution is to use `append`. (https://github.com/vakata/jstree/commit/9c41e435d5aee9647e26500200e30b359bb96ae0)
Can't work for me.

So I imagine this solution with `merge`. I don't know if it's the best, but it seems to work !
