### PR TITLE
Expose defaults globally

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -572,5 +572,6 @@
     $.fn.smoothState = declareSmoothState;
 
     /* expose the default options */
+    $.fn.smoothState.options = defaults;
 
 })(jQuery, window, document);


### PR DESCRIPTION
It's best practice to expose the default options in the plugin.
This allows us to override options both globally and on a per-call level. 
