### PR TITLE
Added `root` option and made `bindEventHandlers` public

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -321,12 +321,14 @@
                  * @param   {string}    url
                  * @param   {bool}      isPopped - used to determine if whe should
                  *                      add a new item into the history object
+                 * @param   {bool}      ignoreCache - whether the cache should be ignored
                  * 
                  */
-                load = function (url, isPopped) {
+                load = function (url, isPopped, ignoreCache) {
                     
                     /** Makes this an optional variable by setting a default */
                     isPopped = isPopped || false;
+                    ignoreCache = ignoreCache || false;
 
                     var
                         /** Used to check if the onProgress function has been run */
@@ -387,7 +389,7 @@
                             }
                         };
                     
-                    if (!cache.hasOwnProperty(url)) {
+                    if (!cache.hasOwnProperty(url) || ignoreCache) {
                         fetch(url);
                     }
                     
@@ -435,12 +437,15 @@
                 /**
                  * Fetches the contents of a url and stores it in the "cache" varible
                  * @param   {string}    url
+                 * @param   {bool}      ignoreCache
                  * 
                  */
-                fetch = function (url) {
+                fetch = function (url, ignoreCache) {
+                    
+                    ignoreCache = ignoreCache || false;
 
                     // Don't fetch we have the content already
-                    if(cache.hasOwnProperty(url)) {
+                    if(cache.hasOwnProperty(url) && !ignoreCache) {
                         return;
                     }
 

--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -297,7 +297,7 @@
                     $page   = $("#" + e.state.id),
                     page    = $page.data("smoothState");
 
-                if(page.href !== url && !utility.isHash(url)) {
+                if(typeof page !== "undefined" && page.href !== url && !utility.isHash(url)) {
                     page.load(url, true);
                 }
             }

--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -11,29 +11,21 @@
 ;(function ( $, window, document, undefined ) {
     "use strict";
 
-    /** Abort plugin if browser does not suppost pushState */
-    if(!history.pushState) {
-        // setup a dummy fn, but don't intercept on link clicks
-        $.fn.smoothState = function() { return this; };
-        $.fn.smoothState.options = {};
-        return;
-    }
-
-    /** Abort if smoothstate is already present **/
-    if($.fn.smoothState) { return; }
-
     var
         /** Used later to scroll page to the top */
-        $body       = $("html, body"),
+        $body       = $('html, body'),
         
         /** Used in development mode to console out useful warnings */
         consl       = (window.console || false),
         
-        /** Plugin default options, will be exposed as $fn.smoothState.options */
+        /** Plugin default options */
         defaults    = {
 
             /** jquery element string to specify which anchors smoothstate should bind to */
             anchors : "a",
+
+            /** jquery object to specify the root element that `onclick` handlers should be bound to */
+            root : null,
 
             /** If set to true, smoothState will prefetch a link's contents on hover */
             prefetch : false,
@@ -64,8 +56,8 @@
             onProgress : {
                 duration: 0,
                 render: function (url, $container) {
-                    $body.css("cursor", "wait");
-                    $body.find("a").css("cursor", "wait");
+                    $body.css('cursor', 'wait');
+                    $body.find('a').css('cursor', 'wait');
                 }
             },
 
@@ -73,8 +65,8 @@
             onEnd : {
                 duration: 0,
                 render: function (url, $container, $content) {
-                    $body.css("cursor", "auto");
-                    $body.find("a").css("cursor", "auto");
+                    $body.css('cursor', 'auto');
+                    $body.find('a').css('cursor', 'auto');
                     $container.html($content);
                 }
             },
@@ -96,10 +88,10 @@
              */
             isExternal: function (url) {
                 var match = url.match(/^([^:\/?#]+:)?(?:\/\/([^\/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/);
-                if (typeof match[1] === "string" && match[1].length > 0 && match[1].toLowerCase() !== window.location.protocol) {
+                if (typeof match[1] === "string" && match[1].length > 0 && match[1].toLowerCase() !== location.protocol) {
                     return true;
                 }
-                if (typeof match[2] === "string" && match[2].length > 0 && match[2].replace(new RegExp(":(" + {"http:": 80, "https:": 443}[window.location.protocol] + ")?$"), "") !== window.location.host) {
+                if (typeof match[2] === "string" && match[2].length > 0 && match[2].replace(new RegExp(":(" + {"http:": 80, "https:": 443}[location.protocol] + ")?$"), "") !== location.host) {
                     return true;
                 }
                 return false;
@@ -124,7 +116,7 @@
              */
             shouldLoad: function ($anchor, blacklist) {
                 var url = $anchor.prop("href");
-                // URL will only be loaded if it"s not an external link, hash, or blacklisted
+                // URL will only be loaded if it's not an external link, hash, or blacklisted
                 return (!utility.isExternal(url) && !utility.isHash(url) && !$anchor.is(blacklist));
             },
 
@@ -139,19 +131,19 @@
                 var parent,
                     elems       = $(),
                     matchTag    = /<(\/?)(html|head|body|title|base|meta)(\s+[^>]*)?>/ig,
-                    prefix      = "ss" + Math.round(Math.random() * 100000),
+                    prefix      = 'ss' + Math.round(Math.random() * 100000),
                     htmlParsed  = html.replace(matchTag, function(tag, slash, name, attrs) {
                         var obj = {};
                         if (!slash) {
-                            $.merge(elems, $("<" + name + "/>"));
+                            elems = elems.add('<' + name + '/>');
                             if (attrs) {
-                                $.each($("<div" + attrs + "/>")[0].attributes, function(i, attr) {
-                                    obj[attr.name] = attr.value;
+                                $.each($('<div' + attrs + '/>')[0].attributes, function(i, attr) {
+                                obj[attr.name] = attr.value;
                                 });
                             }
                             elems.eq(-1).attr(obj);
                         }
-                        return "<" + slash + "div" + (slash ? "" : " id='" + prefix + (elems.length - 1) + "'") + ">";
+                        return '<' + slash + 'div' + (slash ? '' : ' id="' + prefix + (elems.length - 1) + '"') + '>';
                     });
 
                 // If no placeholder elements were necessary, just return normal
@@ -161,14 +153,14 @@
                 }
                 // Create parent node if it hasn't been created yet.
                 if (!parent) {
-                    parent = $("<div/>");
+                    parent = $('<div/>');
                 }
                 // Create the parent node and append the parsed, place-held HTML.
                 parent.html(htmlParsed);
                 
                 // Replace each placeholder element with its intended element.
                 $.each(elems, function(i) {
-                    var elem = parent.find("#" + prefix + i).before(elems[i]);
+                    var elem = parent.find('#' + prefix + i).before(elems[i]);
                     elems.eq(i).html(elem.contents());
                     elem.remove();
                 });
@@ -179,7 +171,7 @@
             /**
              * Resets an object if it has too many properties
              *
-             * This is used to clear the "cache" object that stores
+             * This is used to clear the 'cache' object that stores
              * all of the html. This would prevent the client from
              * running out of memory and allow the user to hit the 
              * server for a fresh copy of the content.
@@ -247,7 +239,7 @@
              * @param   {string}    resetOn - which other events to trigger allanimationend on
              * 
              */
-            triggerAllAnimationEndEvent: function ($element, resetOn) {
+             triggerAllAnimationEndEvent: function ($element, resetOn) {
 
                 resetOn = " " + resetOn || "";
 
@@ -274,7 +266,7 @@
                 $element.on(animationstart, onAnimationStart);
                 $element.on(animationend, onAnimationEnd);
 
-                $element.on("allanimationend" + resetOn, function(){
+                $element.on("allanimationend" + resetOn, function(e){
                     animationCount = 0;
                     utility.redraw($element);
                 });
@@ -282,17 +274,17 @@
 
             /** Forces browser to redraw elements */
             redraw: function ($element) {
-                $element.height();
-                //setTimeout(function(){$element.height("100%");}, 0);
+                $element.height(0);
+			    setTimeout(function(){$element.height('auto');}, 0);
             }
-        }, // eo utility
+        },
 
-        /** Handles the popstate event, like when the user hits "back" */
+        /** Handles the popstate event, like when the user hits 'back' */
         onPopState = function ( e ) {
             if(e.state !== null) {
                 var url     = window.location.href,
-                    $page   = $("#" + e.state.id),
-                    page    = $page.data("smoothState");
+                    $page   = $('#' + e.state.id),
+                    page    = $page.data('smoothState');
                 
                 if(page.href !== url && !utility.isHash(url)) {
                     page.load(url, true);
@@ -347,7 +339,7 @@
                                 }
 
                                 if(!isPopped) {
-                                    window.history.pushState({ id: $container.prop("id") }, cache[url].title, url);
+                                    history.pushState({ id: $container.prop('id') }, cache[url].title, url);
                                 }
                             },
 
@@ -402,12 +394,13 @@
                 /** Updates the contents from cache[url] */
                 updateContent = function (url) {
                     // If the content has been requested and is done:
-                    var containerId = "#" + $container.prop("id"),
-                        $content    = cache[url] ? utility.getContentById(containerId, cache[url].html) : null;
+                    var containerId = '#' + $container.prop('id'),
+                        $content    = utility.getContentById(containerId, cache[url].html);
+
 
                     if($content) {
                         document.title = cache[url].title;
-                        $container.data("smoothState").href = url;
+                        $container.data('smoothState').href = url;
                         
                         // Call the onEnd callback and set trigger
                         options.onEnd.render(url, $container, $content);
@@ -422,7 +415,7 @@
 
                     } else if (!$content && options.development && consl) {
                         // Throw warning to help debug in development mode
-                        consl.warn("No element with an id of " + containerId + " in response from " + url + " in " + cache);
+                        consl.warn("No element with an id of " + containerId + "' in response from " + url + " in " + object);
                     } else {
                         // No content availble to update with, aborting...
                         window.location = url;
@@ -430,16 +423,14 @@
                 },
 
                 /**
-                 * Fetches the contents of a url and stores it in the "cache" varible
+                 * Fetches the contents of a url and stores it in the 'cache' varible
                  * @param   {string}    url
                  * 
                  */
                 fetch = function (url) {
 
                     // Don't fetch we have the content already
-                    if(cache.hasOwnProperty(url)) {
-                        return;
-                    }
+                    if(cache.hasOwnProperty(url)) return;
 
                     cache = utility.clearIfOverCapacity(cache, options.pageCacheSize);
                     
@@ -450,9 +441,9 @@
 
                     // Store contents in cache variable if successful
                     request.success(function (html) {
-                        // Clear cache varible if it"s getting too big
+                        // Clear cache varible if it's getting too big
                         utility.storePageIn(cache, url, html);
-                        $container.data("smoothState").cache = cache;
+                        $container.data('smoothState').cache = cache;
                     });
 
                     // Mark as error
@@ -483,10 +474,10 @@
                  */
                 clickAnchor = function (event) {
                     var $anchor     = $(event.currentTarget),
-                        url         = $anchor.prop("href");
+                        url         = $anchor.prop("href"),
+                        $container  = $(event.delegateTarget);
 
-                    // Ctrl (or Cmd) + click must open a new tab
-                    if (!event.metaKey && !event.ctrlKey && utility.shouldLoad($anchor, options.blacklist)) {
+                    if (utility.shouldLoad($anchor, options.blacklist)) {
                         // stopPropagation so that event doesn't fire on parent containers.
                         event.stopPropagation();
                         event.preventDefault();
@@ -512,7 +503,7 @@
 
                 /** Used to restart css animations with a class */
                 toggleAnimationClass = function (classname) {
-                    var classes = $container.addClass(classname).prop("class");
+                    var classes = $container.addClass(classname).prop('class');
                     
                     $container.removeClass(classes);
                     
@@ -526,12 +517,12 @@
                     
                 };
 
-            /** Merge defaults and global options into current configuration */
-            options = $.extend( {}, $.fn.smoothState.options, options );
+            /** Override defaults with options passed in */
+            options = $.extend(defaults, options);
 
             /** Sets a default state */
-            if(window.history.state === null) {
-                window.history.replaceState({ id: $container.prop("id") }, document.title, currentHref);
+            if(history.state === null) {
+                history.replaceState({ id: $container.prop('id') }, document.title, currentHref);
             }
 
             /** Stores the current page in cache variable */
@@ -541,7 +532,7 @@
             utility.triggerAllAnimationEndEvent($container, "ss.onStartEnd ss.onProgressEnd ss.onEndEnd");
 
             /** Bind all of the event handlers on the container, not anchors */
-            bindEventHandlers($container);
+            bindEventHandlers(options.root ? options.root : $container);
 
             /** Public methods */
             return {
@@ -549,7 +540,8 @@
                 cache: cache,
                 load: load,
                 fetch: fetch,
-                toggleAnimationClass: toggleAnimationClass
+                toggleAnimationClass: toggleAnimationClass,
+                bindEventHandlers: bindEventHandlers
             };
         },
 
@@ -557,9 +549,9 @@
         declareSmoothState = function ( options ) {
             return this.each(function () {
                 // Checks to make sure the smoothState element has an id and isn't already bound
-                if(this.id && !$.data(this, "smoothState")) {
-                    // Makes public methods available via $("element").data("smoothState");
-                    $.data(this, "smoothState", new SmoothState(this, options));
+                if(this.id && !$.data(this, 'smoothState')) {
+                    // Makes public methods available via $('element').data('smoothState');
+                    $.data(this, 'smoothState', new SmoothState(this, options));
                 } else if (!this.id && consl) {
                     // Throw warning if in development mode
                     consl.warn("Every smoothState container needs an id but the following one does not have one:", this);
@@ -575,8 +567,5 @@
 
     /** Defines the smoothState plugin */
     $.fn.smoothState = declareSmoothState;
-
-    /* expose the default options */
-    $.fn.smoothState.options = defaults;
 
 })(jQuery, window, document);

--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -1,12 +1,12 @@
 /**
  * smoothState.js is a jQuery plugin to stop page load jank.
  *
- * This jQuery plugin progressively enhances page loads to 
+ * This jQuery plugin progressively enhances page loads to
  * behave more like a single-page application.
  *
  * @author  Miguel Ángel Pérez   reachme@miguel-perez.com
  * @see     https://github.com/miguel-perez/jquery.smoothState.js
- * 
+ *
  */
 ;(function ( $, window, document, undefined ) {
     "use strict";
@@ -25,36 +25,36 @@
     var
         /** Used later to scroll page to the top */
         $body       = $("html, body"),
-        
+
         /** Used in development mode to console out useful warnings */
         consl       = (window.console || false),
-        
+
         /** Plugin default options, will be exposed as $fn.smoothState.options */
         defaults    = {
 
             /** jquery element string to specify which anchors smoothstate should bind to */
             anchors : "a",
-            
+
             /** jquery object to specify the root element that `onclick` handlers should be bound to */
             root : null,
 
             /** If set to true, smoothState will prefetch a link's contents on hover */
             prefetch : false,
-            
+
             /** A selecor that deinfes with links should be ignored by smoothState */
             blacklist : ".no-smoothstate, [target]",
-            
+
             /** If set to true, smoothState will log useful debug information instead of aborting */
             development : false,
-            
+
             /** The number of pages smoothState will try to store in memory and not request again */
             pageCacheSize : 0,
-            
+
             /** A function that can be used to alter urls before they are used to request content */
             alterRequestUrl : function (url) {
                 return url;
             },
-            
+
             /** Run when a link has been activated */
             onStart : {
                 duration: 0,
@@ -87,7 +87,7 @@
 
             }
         },
-        
+
         /** Utility functions that are decoupled from SmoothState */
         utility     = {
 
@@ -95,7 +95,7 @@
              * Checks to see if the url is external
              * @param   {string}    url - url being evaluated
              * @see     http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls
-             * 
+             *
              */
             isExternal: function (url) {
                 var match = url.match(/^([^:\/?#]+:)?(?:\/\/([^\/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/);
@@ -111,7 +111,7 @@
             /**
              * Checks to see if the url is an internal hash
              * @param   {string}    url - url being evaluated
-             * 
+             *
              */
             isHash: function (url) {
                 var hasPathname = (url.indexOf(window.location.pathname) > 0) ? true : false,
@@ -123,7 +123,7 @@
              * Checks to see if we should be loading this URL
              * @param   {string}    url - url being evaluated
              * @param   {string}    blacklist - jquery selector
-             * 
+             *
              */
             shouldLoad: function ($anchor, blacklist) {
                 var url = $anchor.prop("href");
@@ -136,7 +136,7 @@
              * @param   {string}    url - url being evaluated
              * @author  Ben Alman   http://benalman.com/
              * @see     https://gist.github.com/cowboy/742952
-             * 
+             *
              */
             htmlDoc: function (html) {
                 var parent,
@@ -168,7 +168,7 @@
                 }
                 // Create the parent node and append the parsed, place-held HTML.
                 parent.html(htmlParsed);
-                
+
                 // Replace each placeholder element with its intended element.
                 $.each(elems, function(i) {
                     var elem = parent.find("#" + prefix + i).before(elems[i]);
@@ -184,12 +184,12 @@
              *
              * This is used to clear the "cache" object that stores
              * all of the html. This would prevent the client from
-             * running out of memory and allow the user to hit the 
+             * running out of memory and allow the user to hit the
              * server for a fresh copy of the content.
              *
              * @param   {object}    obj
              * @param   {number}    cap
-             * 
+             *
              */
             clearIfOverCapacity: function (obj, cap) {
                 // Polyfill Object.keys if it doesn't exist
@@ -217,7 +217,7 @@
              * Finds the inner content of an element, by an ID, from a jQuery object
              * @param   {string}    id
              * @param   {object}    $html
-             * 
+             *
              */
             getContentById: function (id, $html) {
                 $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
@@ -232,7 +232,7 @@
              * @param   {object}    object - object contents will be stored into
              * @param   {string}    url - url to be used as the prop
              * @param   {jquery}    html - contents to store
-             * 
+             *
              */
             storePageIn: function (object, url, $html) {
                 $html = ($html instanceof jQuery) ? $html : utility.htmlDoc($html);
@@ -248,7 +248,7 @@
              * Triggers an "allanimationend" event when all animations are complete
              * @param   {object}    $element - jQuery object that should trigger event
              * @param   {string}    resetOn - which other events to trigger allanimationend on
-             * 
+             *
              */
             triggerAllAnimationEndEvent: function ($element, resetOn) {
 
@@ -296,7 +296,7 @@
                 var url     = window.location.href,
                     $page   = $("#" + e.state.id),
                     page    = $page.data("smoothState");
-                
+
                 if(page.href !== url && !utility.isHash(url)) {
                     page.load(url, true);
                 }
@@ -308,24 +308,24 @@
             var
                 /** Container element smoothState is run on */
                 $container  = $(element),
-                
+
                 /** Variable that stores pages after they are requested */
                 cache       = {},
-                
+
                 /** Url of the content that is currently displayed */
                 currentHref = window.location.href,
 
                 /**
-                 * Loads the contents of a url into our container 
+                 * Loads the contents of a url into our container
                  *
                  * @param   {string}    url
                  * @param   {bool}      isPopped - used to determine if whe should
                  *                      add a new item into the history object
                  * @param   {bool}      ignoreCache - whether the cache should be ignored
-                 * 
+                 *
                  */
                 load = function (url, isPopped, ignoreCache) {
-                    
+
                     /** Makes this an optional variable by setting a default */
                     isPopped = isPopped || false;
                     ignoreCache = ignoreCache || false;
@@ -335,7 +335,7 @@
                         hasRunCallback  = false,
 
                         callbBackEnded  = false,
-                        
+
                         /** List of responses for the states of the page request */
                         responses       = {
 
@@ -358,23 +358,23 @@
 
                             /** Loading, wait 10 ms and check again */
                             fetching: function() {
-                                
+
                                 if(!hasRunCallback) {
-                                    
+
                                     hasRunCallback = true;
-                                    
+
                                     // Run the onProgress callback and set trigger
                                     $container.one("ss.onStartEnd", function(){
                                         options.onProgress.render(url, $container, null);
-                                        
+
                                         setTimeout(function(){
                                             $container.trigger("ss.onProgressEnd");
                                             callbBackEnded = true;
                                         }, options.onStart.duration);
-                                    
+
                                     });
                                 }
-                                
+
                                 setTimeout(function () {
                                     // Might of been canceled, better check!
                                     if(cache.hasOwnProperty(url)){
@@ -388,11 +388,11 @@
                                 window.location = url;
                             }
                         };
-                    
+
                     if (!cache.hasOwnProperty(url) || ignoreCache) {
-                        fetch(url);
+                        fetch(url, ignoreCache);
                     }
-                    
+
                     // Run the onStart callback and set trigger
                     options.onStart.render(url, $container, null);
                     setTimeout(function(){
@@ -413,7 +413,7 @@
                     if($content) {
                         document.title = cache[url].title;
                         $container.data("smoothState").href = url;
-                        
+
                         // Call the onEnd callback and set trigger
                         options.onEnd.render(url, $container, $content);
 
@@ -435,13 +435,13 @@
                 },
 
                 /**
-                 * Fetches the contents of a url and stores it in the "cache" varible
+                 * Fetches the contents of a url and stores it in the "cache" variable
                  * @param   {string}    url
                  * @param   {bool}      ignoreCache
-                 * 
+                 *
                  */
                 fetch = function (url, ignoreCache) {
-                    
+
                     ignoreCache = ignoreCache || false;
 
                     // Don't fetch we have the content already
@@ -450,7 +450,7 @@
                     }
 
                     cache = utility.clearIfOverCapacity(cache, options.pageCacheSize);
-                    
+
                     cache[url] = { status: "fetching" };
 
                     var requestUrl  = options.alterRequestUrl(url) || url,
@@ -472,7 +472,7 @@
                  * Binds to the hover event of a link, used for prefetching content
                  *
                  * @param   {object}    event
-                 * 
+                 *
                  */
                 hoverAnchor = function (event) {
                     var $anchor = $(event.currentTarget),
@@ -487,7 +487,7 @@
                  * Binds to the click event of a link, used to show the content
                  *
                  * @param   {object}    event
-                 * 
+                 *
                  */
                 clickAnchor = function (event) {
                     var $anchor     = $(event.currentTarget),
@@ -506,7 +506,7 @@
                  * Binds all events and inits functionality
                  *
                  * @param   {object}    event
-                 * 
+                 *
                  */
                 bindEventHandlers = function ($element) {
                     //@todo: Handle form submissions
@@ -521,9 +521,9 @@
                 /** Used to restart css animations with a class */
                 toggleAnimationClass = function (classname) {
                     var classes = $container.addClass(classname).prop("class");
-                    
+
                     $container.removeClass(classes);
-                    
+
                     setTimeout(function(){
                         $container.addClass(classes);
                     },0);
@@ -531,7 +531,7 @@
                     $container.one("ss.onStartEnd ss.onProgressEnd ss.onEndEnd", function(){
                         $container.removeClass(classname);
                     });
-                    
+
                 };
 
             /** Merge defaults and global options into current configuration */


### PR DESCRIPTION
The `root` option determines where the `click`, `mouseover` and `touchstart` events should be bound to. This allows links outside of the $container to load using SmoothState.js.

`root` can be used like so:

```
$("#page").smoothState({
    root: $(document)
}).data('smoothState');
```

`bindEventHandlers` has been made public to allow the user to manually rebind all events. For example: if `$("*").off()` has been called, and all event handlers have been destroyed, then it is necessary to re bind SmoothState's events.

An example from one of my projects:

```
render: function(url, container, content) {
        $("html, body").css('cursor', 'auto')
             .find('a').css('cursor', 'auto');
        container.html(content)
        elements = $(document).add("*")
        elements.off() // removes all previous events to stop double registration when calling `initialisePage()`
        smoothState.bindEventHandlers($(document))
        initialisePage()
}
```

Hopefully you find these additions useful!
