### PR TITLE
Acces to the full ajax response from the onEnd callback

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -410,10 +410,10 @@
                         $container.data("smoothState").href = url;
                         
                         // Call the onEnd callback and set trigger
-                        options.onEnd.render(url, $container, $content);
+                        options.onEnd.render(url, $container, $content, cache[url].html);
 
                         $container.one("ss.onEndEnd", function(){
-                            options.callback(url, $container, $content);
+                            options.callback(url, $container, $content, cache[url].html);
                         });
 
                         setTimeout(function(){


### PR DESCRIPTION
I found myself in need to access the full ajax response within the onEnd callback so i added it as an extra parameter. If you run the smootstate on the body container and want to copy the new body classes from the ajax response (for css styling to stay intact) then this looks like a logical way to achive this. Well at least for me. This might even have other use cases. For example hooking into changes in het html header.
