### PR TITLE
Force ajax dataType to html

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -446,7 +446,7 @@
                     cache[url] = { status: "fetching" };
 
                     var requestUrl  = options.alterRequestUrl(url) || url,
-                        request     = $.ajax(requestUrl);
+                        request     = $.ajax(requestUrl, { dataType: "html" });
 
                     // Store contents in cache variable if successful
                     request.success(function (html) {


### PR DESCRIPTION
This fixes the "html.replace is not a function" error.

`utility.storePageIn` requires the 3rd parameter to be a jQuery or a string. But, on line ~452, the ajax success callback caller sometimes passes an XMLDocument object (instead of an HTML string) to the `html` parameter in the callback. This is passed to `ulitity.storePageIn` which expects a jQuery or a string.

This change forces the request result to be an HTML string, instead of the default auto-guessing.
