### PR TITLE
Fix isHash() when using the back-button

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -111,7 +111,7 @@
              * 
              */
             isHash: function (url) {
-                var hasPathname = (window.location.href.indexOf(url) > 0) ? true : false,
+                var hasPathname = (window.location.href.indexOf(url) >= 0) ? true : false,
                     hasHash = (url.indexOf("#") > 0) ? true : false;
                 return (hasPathname && hasHash) ? true : false;
             },


### PR DESCRIPTION
This fixes #57, whose core bug is that `isHash` returns `true` when the last page has a hash but is not the same page as the current.

It is because `onPopState` is called on load, that in the `isHash` function, in the `hasPathname` check, `window.location.pathname` already contains the current url - equal to `url` plus the protocol and domain minus the hash. This makes `hasPathname` true when it should not be. (I assume `hasPathname` means "same page.")

I replaced the `hasPathname` check with one that uses `window.location.href` instead of the `window.location.pathname`. This one is contains the previous page's url.
