### PR TITLE
Fix back-button not loading hash urls

### DIFF
--- a/jquery.smoothState.js
+++ b/jquery.smoothState.js
@@ -108,10 +108,12 @@
             /**
              * Checks to see if the url is an internal hash
              * @param   {string}    url - url being evaluated
+             * @param   {string}    prev - previous url (optional)
              * 
              */
-            isHash: function (url) {
-                var hasPathname = (url.indexOf(window.location.pathname) > 0) ? true : false,
+            isHash: function (url, prev = null) {
+                prev = prev || window.location.pathname;
+                var hasPathname = (url.indexOf(prev) >= 0) ? true : false,
                     hasHash = (url.indexOf("#") > 0) ? true : false;
                 return (hasPathname && hasHash) ? true : false;
             },
@@ -294,7 +296,7 @@
                     $page   = $("#" + e.state.id),
                     page    = $page.data("smoothState");
                 
-                if(page.href !== url && !utility.isHash(url)) {
+                if(page.href !== url && !utility.isHash(url, page.href)) {
                     page.load(url, true);
                 }
             }


### PR DESCRIPTION
Fixes #57 - pop state does not load the previous page if that page has a hash in the url.

Changed `onPopState` and `isHash`.

`isHash` gets the source url from `window.location.pathname` but it no longer holds the source url when `onpopstate` is triggered. `window.location.pathname` already holds the destination url on `onpopstate`.

I made it so that `onPopState` expilicitly tells `isHash` what the source url is to compare with the destination url.
