### PR TITLE
Check for falsey values of options.achors and options.forms

### DIFF
--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -605,12 +605,15 @@
          */
         bindEventHandlers = function ($element) {
 
-          $element.on('click', options.anchors, clickAnchor);
+          if (options.anchors) {
+            $element.on('click', options.anchors, clickAnchor);
+            if (options.prefetch) {
+              $element.on(options.prefetchOn, options.anchors, hoverAnchor);
+            }
+          }
 
-          $element.on('submit', options.forms, submitForm);
-
-          if (options.prefetch) {
-            $element.on(options.prefetchOn, options.anchors, hoverAnchor);
+          if (options.forms) {
+            $element.on('submit', options.forms, submitForm);
           }
         },
 


### PR DESCRIPTION
Hey there,

I ran into smoothState.js just a little while ago and I think it's really pretty awesome. It seems like a fantastic way to get a similar kind of snappy UI response and UX that otherwise would appear to be the territory of only SPAs.

I started to put together a theme recently using OctoberCMS and smoothState. Now, OctoberCMS has its own specialized AJAX form handling code, and so inter-operation with smoothState's form handling became an issue. A major thing was that my forms are simply not going to return a rendered page to the caller since i'm just making API calls, so I wanted to disable smoothState's form handling only to discover that setting options.forms="" results in an exception being thrown by jQuery and my page's scripts breaking down. There are other ways I could disable this, I suppose, but I figured I could contribute a small patch as a way to start getting involved.

This PR is a simple check for falsey values of options.anchors and options.forms in the bindEventHandlers function so that if either is set to empty string (or any other falsey value), jQuery.on() just won't be called, avoiding the exception (in the same way options.prefetchOn is tested).

The results of the change is that smoothState provides a mechanism to optionally disable handling of anchors and/or forms by providing a falsey selector (such as empty string) for either in the options object.

After the change all tests continue to pass. Let me know if there's any way I can better follow your coding standards or if, perhaps, I am totally doing something incorrectly!

Jeff
