### PR TITLE
added the unedited ajax reponse to the cache object

### DIFF
--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -223,6 +223,7 @@
           // Stores the title of the page, .first() prevents getting svg titles
           title: $html.find('title').first().text(),
           html: $html.find('#' + id), // Stores the contents of the page
+          doc: doc, // Stores the whole page document
         };
         return object;
       },


### PR DESCRIPTION
Added the ajax response to the cache object so developers can use it.

`smoothState.cache[<--insert url-->].doc` will return this.
