### PR TITLE
Correct a URL in demos/index.html

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -2,5 +2,5 @@
 <ul>
   <li><a href="./barebones/index.html">Barebones Demo</a></li>
   <li><a href="./csstricks/index.html">CSSTricks Demo</a></li>
-  <li><a href="./csstricks/anchor-transitions.html">Demo with different transitions based on anchor</a></li>
+  <li><a href="./anchor-transitions/index.html">Demo with different transitions based on anchor</a></li>
 </ul>


### PR DESCRIPTION
Url of the anchor-transitions demo in demos/index.html is wrong, fixed.
