### PR TITLE
Allow the server to set the history stack by setting a header

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,7 @@
   "undef": true,
   "unused": "vars",
   "strict": true,
-  "maxparams": 4,
+  "maxparams": 5,
   "maxdepth": 4,
   "maxstatements": 15,
   "maxcomplexity": 7

--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -378,7 +378,7 @@
 
           // Store contents in cache variable if successful
           ajaxRequest.done(function (html) {
-            utility.storePageIn(cache, settings.url, html, elementId);
+            utility.storePageIn(cache, settings.url, html, elementId, settings.url);
             $container.data('smoothState').cache = cache;
           });
 
@@ -717,7 +717,7 @@
       }
 
       /** Stores the current page in cache variable */
-      utility.storePageIn(cache, currentHref, document.documentElement.outerHTML, elementId);
+      utility.storePageIn(cache, currentHref, document.documentElement.outerHTML, elementId, currentHref);
 
       /** Bind all of the event handlers on the container, not anchors */
       utility.triggerAllAnimationEndEvent($container, 'ss.onStartEnd ss.onProgressEnd ss.onEndEnd');

--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -233,6 +233,7 @@
        * @param   {string}    url - name of the entry
        * @param   {string|document}    doc - entire html
        * @param   {string}    id - the id of the fragment
+       * @param   {string}    destUrl - the destination url
        *
        */
       storePageIn: function (object, url, doc, id, destUrl) {
@@ -392,7 +393,9 @@
 
           ajaxRequest.complete(function(request, status) {
             var currentLocationHeader = request.getResponseHeader('Current-Location');
-            if (currentLocationHeader) cache[settings.url].destUrl = currentLocationHeader;
+            if (currentLocationHeader) {
+              cache[settings.url].destUrl = currentLocationHeader;
+            }
           });
         },
 


### PR DESCRIPTION
I ran into a problem where page X submits a form to page Y and page Y redirects to page X.
smoothState was adding page Y to the history stack instead of page X, because AJAX follows requests silently.

Now the server can send a header 'Current-Location' to tell smoothState which URL it should add to the history stack of the browser. If the header is not given, it will work normally using the submission/href URL.
