### PR TITLE
Fix usage of wrong var name

### DIFF
--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -320,7 +320,7 @@
           $page = $('#' + e.state.id),
           page = $page.data('smoothState'),
           diffUrl = (page.href !== url && !utility.isHash(url, page.href)),
-          diffState = (event.state !== page.cache[page.href].state);
+          diffState = (e.state !== page.cache[page.href].state);
 
         if(diffUrl || diffState) {
           if (diffState) {


### PR DESCRIPTION
It looks like there is an accidentally usage of a wrong variable name.
