### PR TITLE
BindPrefetchHandlers

### DIFF
--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -714,13 +714,12 @@
          * Binds prefetch events
          * @param   {object}    event
          */
-		bindPrefetchHandlers = function ($element) {
-			
+        bindPrefetchHandlers = function ($element) {
+            		
           if (options.anchors && options.prefetch) {
             $element.find(options.anchors).not(options.prefetchBlacklist).on(options.prefetchOn, null, hoverAnchor);
           }
-			
-		},
+        },
 		
         /**
          * Binds all events and inits functionality

--- a/src/jquery.smoothState.js
+++ b/src/jquery.smoothState.js
@@ -320,7 +320,7 @@
           $page = $('#' + e.state.id),
           page = $page.data('smoothState'),
           diffUrl = (page.href !== url && !utility.isHash(url, page.href)),
-          diffState = (event.state !== page.cache[page.href].state);
+          diffState = (e.state !== page.cache[page.href].state);
 
         if(diffUrl || diffState) {
           if (diffState) {
@@ -465,6 +465,8 @@
               if (options.scroll) {
                 repositionWindow();
               }
+              
+              bindPrefetchHandlers($container);
 
             });
 
@@ -707,7 +709,19 @@
         setRateLimitRepeatTime = function () {
           rateLimitRepeatTime = parseInt(Date.now()) + parseInt(options.repeatDelay);
         },
-
+        
+        /**
+         * Binds prefetch events
+         * @param   {object}    event
+         */
+		bindPrefetchHandlers = function ($element) {
+			
+          if (options.anchors && options.prefetch) {
+            $element.find(options.anchors).not(options.prefetchBlacklist).on(options.prefetchOn, null, hoverAnchor);
+          }
+			
+		},
+		
         /**
          * Binds all events and inits functionality
          * @param   {object}    event
@@ -717,9 +731,7 @@
           if (options.anchors) {
             $element.on('click', options.anchors, clickAnchor);
 
-            if (options.prefetch) {
-              $element.find(options.anchors).not(options.prefetchBlacklist).on(options.prefetchOn, null, hoverAnchor);
-            }
+            bindPrefetchHandlers($element);
           }
 
           if (options.forms) {
@@ -756,6 +768,7 @@
 
       /** Bind all of the event handlers on the container, not anchors */
       bindEventHandlers($container);
+
 
       /** Public methods */
       return {


### PR DESCRIPTION
I noticed the prefetch on anchor hover stopped working once a new page had been transitioned to and contained new anchors.

This PR moves the prefetch event binding into a separate method and is called in the ss.onReadyEnd callback so newly added anchors are bound.

You could call the existing bindEventHandlers method but that would rebind the click events which were still correctly bound.
