### PR TITLE
Remove CNAME from GitHub Pages.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-smoothstate.com


### PR DESCRIPTION
Howdy, I was looking into using your plugin and got redirected to some spam from clicking the [homepage link on NPM](https://www.npmjs.com/package/smoothstate). At first glance, it seems like it will go to [GitHub Pages](http://miguel-perez.github.io/smoothState.js/) but due to the CNAME it redirects to http://smoothstate.com which is currently forwarding people to spam ☹️

Meanwhile we can't see the GitHub Pages URL because of the CNAME file. This PR fixes the problem and restores docs on the github.io domain. GitHub Pages now offers free HTTPS so it's a fine solution, but if you do want a "prettier" URL maybe you could grab a namespace on https://dns.js.org — it's free for an open-source project like yours.